### PR TITLE
ヘッダーに朝食人数を表示する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,15 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :get_people_management
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :managers_name])
+  end
+
+  def get_people_management
+    @people_management = PeopleManagement.find(1)
   end
 end

--- a/app/controllers/people_managements_controller.rb
+++ b/app/controllers/people_managements_controller.rb
@@ -1,10 +1,10 @@
 class PeopleManagementsController < ApplicationController
   def edit
-    @people_management = PeopleManagement.find(1)
+    # ApplicationControllerでpeople_management(１)を取得しているため、ここでは取得していない
   end
 
   def update
-    @people_management = PeopleManagement.find(1)
+    # ApplicationControllerでpeople_management(１)を取得しているため、ここでは取得していない
     if @people_management.update(people_management_params)
       redirect_to root_path
     else

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,6 +7,7 @@
         <ul class="menu-item"><%= link_to '人数', root_path, class: "menu" %></ul>
         <ul class="menu-item"><%= link_to '天気', root_path, class: "menu" %></ul>
         <ul class="menu-item"><%= link_to 'その他メニュー', other_functions_path, class: "menu" %></ul>
+        <ul class="menu-item"><%= link_to @people_management.morning, edit_people_management_path(1), class: "menu" %></ul>
       </li>
   </div>
 </header>


### PR DESCRIPTION
## people managementのmorningの人数を表示する

キッチンとホールで人数を把握し合えるようにするため。
逐一更新し、残り何人あの家をすぐに把握できるように、ヘッダーに表示させる。